### PR TITLE
OAuth flow fails if the redirect URL provided to Capsule contains query params

### DIFF
--- a/lib/omniauth/strategies/capsule.rb
+++ b/lib/omniauth/strategies/capsule.rb
@@ -21,6 +21,10 @@ module OmniAuth
         super
       end
 
+      def callback_url
+        full_host + script_name + callback_path
+      end
+
       uid { raw_info['id'].to_s }
 
       info do


### PR DESCRIPTION
OAuth flow fails if the redirect URL provided to Capsule when obtaining an Authorization code contains query params

![2019-03-24 at 12 20 AM](https://user-images.githubusercontent.com/1789832/54870299-aa746c80-4dca-11e9-9a13-b21914da5a29.png)
